### PR TITLE
Compatibility shim library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ repositories {
 }
 
 ext {
-    kafkaVersion = "1.1.0"
+    kafkaVersion = "3.3.0"
     parquetVersion = "1.11.1"
     junitVersion = "5.9.0"
     confluentPlatformVersion = "7.2.1"
@@ -103,13 +103,44 @@ distributions {
     }
 }
 
+def featureTestingVersions = [
+        '0101' : '0.10.1.0',
+        '0102' : '0.10.2.0',
+        '250' : '2.5.0',
+        '260' : '2.6.0',
+        '320' : '3.2.0',
+        '330' : '3.3.0'
+]
+
+configurations {
+    featureTestingVersions.keySet().forEach(name -> {
+        configurations.create("kafka$name")
+        configurations.getByName("kafka$name").extendsFrom(testImplementation)
+    })
+
+    kafkaLatest.extendsFrom(testImplementation)
+}
+
 dependencies {
     compileOnly "org.apache.kafka:connect-api:$kafkaVersion"
     compileOnly "org.apache.kafka:connect-runtime:$kafkaVersion"
     compileOnly "org.apache.kafka:connect-json:$kafkaVersion"
+    // Make sure not to include the API artifact by default at runtime for tests, since we test against different
+    // versions of it
+    testCompileOnly "org.apache.kafka:connect-api:$kafkaVersion"
+
+    featureTestingVersions.forEach((name, version) -> {
+        add("kafka$name", "org.apache.kafka:connect-api:$version")
+    })
+
+    kafkaLatest "org.apache.kafka:connect-api:$kafkaVersion"
+    kafkaLatest "org.apache.kafka:connect-runtime:$kafkaVersion"
+    kafkaLatest "org.apache.kafka:connect-json:$kafkaVersion"
+    kafkaLatest "org.apache.kafka:kafka-clients:$kafkaVersion"
 
     implementation("io.confluent:kafka-connect-avro-converter:$confluentPlatformVersion") {
         exclude group: "org.apache.kafka", module: "kafka-clients"
+        exclude group: "org.apache.kafka", module: "connect-api"
     }
 
     implementation "org.xerial.snappy:snappy-java:1.1.8.4"
@@ -162,9 +193,6 @@ dependencies {
         exclude group: "io.netty", module: "netty"
     }
 
-    testImplementation "org.apache.kafka:connect-api:$kafkaVersion"
-    testImplementation "org.apache.kafka:connect-runtime:$kafkaVersion"
-    testImplementation "org.apache.kafka:connect-json:$kafkaVersion"
     testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
     testImplementation "org.apache.parquet:parquet-tools:$parquetVersion"
     testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.3"
@@ -177,15 +205,39 @@ dependencies {
     testImplementation "org.apache.hadoop:hadoop-mapreduce-client-core:3.3.4"
 
     testImplementation "com.fasterxml.jackson.core:jackson-databind:2.13.3"
-    testImplementation "io.confluent:kafka-connect-avro-converter:$confluentPlatformVersion"
+    testImplementation("io.confluent:kafka-connect-avro-converter:$confluentPlatformVersion") {
+        exclude group: "org.apache.kafka", module: "kafka-clients"
+        exclude group: "org.apache.kafka", module: "connect-api"
+    }
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }
 
 test {
+    filter {
+        exclude "io/aiven/kafka/connect/common/compatibility/features/**"
+    }
+    classpath += configurations.kafkaLatest
     useJUnitPlatform()
 }
+
+featureTestingVersions.keySet().forEach(name -> {
+    tasks.create(name: "testFeatures$name", type: Test) {
+        filter {
+            includeTestsMatching "FeaturesTest.testFeatures$name"
+        }
+        classpath += configurations.getByName("kafka$name")
+        useJUnitPlatform()
+    }
+
+})
+
+task allTests {
+    dependsOn tasks.withType(Test)
+}
+
+build.dependsOn(allTests)
 
 publishing {
     publications {

--- a/src/main/java/io/aiven/kafka/connect/common/compatibility/DisabledErrantRecordReporter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/compatibility/DisabledErrantRecordReporter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.compatibility;
+
+import java.util.concurrent.Future;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+/**
+ * An {@link ErrantRecordReporter} that always throws an exception from {@link #report(SinkRecord, Throwable)}, and
+ * provides a helpful message to the user containing instructions on how to enable the errant record reporter depending
+ * on whether it is unsupported by the Kafka Connect runtime, or supported but not enabled by the user.
+ */
+class DisabledErrantRecordReporter implements ErrantRecordReporter {
+
+    private final boolean supported;
+
+    public DisabledErrantRecordReporter(final boolean supported) {
+        this.supported = supported;
+    }
+
+    @Override
+    public Future<Void> report(final SinkRecord record, final Throwable error) {
+        final String preamble = String.format(
+                "An error was encountered with the record from topic/partition/offset %s/%s/%s",
+                record.topic(),
+                record.kafkaPartition(),
+                record.kafkaOffset()
+        );
+        final String message;
+        if (supported) {
+            message = preamble + ". Consider enabling the \"errors.tolerance\" property in your connector "
+                    + "configuration if you would like to skip invalid records such as this one.";
+        } else {
+            message = preamble + ", "
+                    + "and the version of Kafka Connect that this connector is deployed onto does not support "
+                    + "the errant record reporter feature. Consider upgrading to version 2.6.0 or later if you would "
+                    + "like to skip invalid records such as this one.";
+        }
+        throw new ConnectException(message, error);
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/connect/common/compatibility/ErrantRecordReporter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/compatibility/ErrantRecordReporter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.compatibility;
+
+import java.util.concurrent.Future;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+
+import io.aiven.kafka.connect.common.compatibility.features.Features;
+
+/**
+ * This interface is a shim for the {@link org.apache.kafka.connect.sink.ErrantRecordReporter} interface that
+ * developers can use in their connectors without having to sacrifice compatibility with older versions of the Kafka
+ * Connect framework or deal with reflection errors.
+ * @see Features#SINK_TASK_ERRANT_RECORD_REPORTER
+ */
+public interface ErrantRecordReporter {
+
+    /**
+     * @param record the invalid record
+     * @param error the error with the record
+     * @return the result of reporting the error with the record
+     * @see org.apache.kafka.connect.sink.ErrantRecordReporter#report(SinkRecord, Throwable)
+     */
+    Future<Void> report(SinkRecord record, Throwable error);
+
+    /**
+     * Get a reporter that can be used for this connector. If the runtime does not support the
+     * {@link org.apache.kafka.connect.sink.ErrantRecordReporter} interface, or if the user has not configured this
+     * connector to use an error reporter, returns a default implementation whose
+     * {@link #report(SinkRecord, Throwable)} method always throws an exception.
+     * @param context the {@link SinkTaskContext} that the task has been instantiated with
+     * @return a reporter that can be used by the task; never null
+     */
+    static ErrantRecordReporter reporter(final SinkTaskContext context) {
+        if (Features.SINK_TASK_ERRANT_RECORD_REPORTER.supported()) {
+            final org.apache.kafka.connect.sink.ErrantRecordReporter userConfigured = context.errantRecordReporter();
+            return userConfigured != null
+                    ? new SupportedErrantRecordReporter(userConfigured)
+                    : new DisabledErrantRecordReporter(true);
+        } else {
+            return new DisabledErrantRecordReporter(false);
+        }
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/connect/common/compatibility/SupportedErrantRecordReporter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/compatibility/SupportedErrantRecordReporter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.compatibility;
+
+import java.util.Objects;
+import java.util.concurrent.Future;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+/**
+ * An {@link ErrantRecordReporter} that simply delegates all calls to an
+ * {@link org.apache.kafka.connect.sink.ErrantRecordReporter}, which should be provided by the Kafka Connect runtime.
+ */
+class SupportedErrantRecordReporter implements ErrantRecordReporter {
+
+    private final org.apache.kafka.connect.sink.ErrantRecordReporter reporter;
+
+    public SupportedErrantRecordReporter(final org.apache.kafka.connect.sink.ErrantRecordReporter reporter) {
+        this.reporter = Objects.requireNonNull(reporter);
+    }
+
+    @Override
+    public Future<Void> report(final SinkRecord record, final Throwable error) {
+        return reporter.report(record, error);
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/connect/common/compatibility/features/Feature.java
+++ b/src/main/java/io/aiven/kafka/connect/common/compatibility/features/Feature.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.compatibility.features;
+
+/**
+ * A {@link Feature} represents a part of the Kafka Connect API whose availability depends on teh version of the Kafka
+ * Connect runtime that the connector (or converter, or transform, etc.) is deployed onto.
+ */
+public abstract class Feature {
+
+    private Boolean supported;
+
+    protected Feature() {
+        supported = null;
+    }
+
+    /**
+     * Check to see if the feature is supported. This method will be invoked at most once over the lifetime of this
+     * instance; subclasses do not need to implement caching logic.
+     * @return whether the feature is supported
+     */
+    protected abstract boolean checkSupported();
+
+    /**
+     * @return a human-readable name for the feature, such as "Sink task preCommit" or
+     *     "Source task defined transactions"
+     */
+    public abstract String toString();
+
+    /**
+     * Determine whether the given feature is supported by the current Kafka Connect runtime
+     * @return whether the feature is supported
+     */
+    public boolean supported() {
+        if (supported != null) {
+            return supported;
+        }
+        synchronized (this) {
+            if (supported != null) {
+                return supported;
+            }
+            return supported = checkSupported();
+        }
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/connect/common/compatibility/features/Features.java
+++ b/src/main/java/io/aiven/kafka/connect/common/compatibility/features/Features.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.compatibility.features;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.sink.SinkTask;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.source.SourceTaskContext;
+
+/**
+ * This class allows developers to easily check at any point in the lifetime of a Kafka Connect plugin (connector,
+ * converter, etc.) whether features of the Kafka Connect runtime that the plugin has been deployed onto are supported.
+ */
+public interface Features {
+
+    /**
+     * @see SinkTask#preCommit(Map)
+     */
+    Feature SINK_TASK_PRE_COMMIT = new MethodFeature() {
+        @Override
+        protected Class<?> klass() {
+            return SinkTask.class;
+        }
+
+        @Override
+        protected String method() {
+            return "preCommit";
+        }
+
+        @Override
+        protected List<Class<?>> parameters() {
+            return Arrays.asList(Map.class);
+        }
+
+        @Override
+        public String toString() {
+            return "Sink task preCommit";
+        }
+    };
+
+    /**
+     * @see SinkTaskContext#errantRecordReporter()
+     */
+    Feature SINK_TASK_ERRANT_RECORD_REPORTER = new MethodFeature() {
+        @Override
+        protected Class<?> klass() {
+            return SinkTaskContext.class;
+        }
+
+        @Override
+        protected String method() {
+            return "errantRecordReporter";
+        }
+
+        @Override
+        protected List<Class<?>> parameters() {
+            return Arrays.asList();
+        }
+
+        @Override
+        public String toString() {
+            return "Sink task errant record reporter";
+        }
+    };
+
+    /**
+     * @see SourceConnector#exactlyOnceSupport(Map)
+     * @see SourceTaskContext#transactionContext()
+     */
+    Feature EXACTLY_ONCE_SOURCE_CONNECTORS = new MethodFeature() {
+        @Override
+        protected Class<?> klass() {
+            return SourceConnector.class;
+        }
+
+        @Override
+        protected String method() {
+            return "exactlyOnceSupport";
+        }
+
+        @Override
+        protected List<Class<?>> parameters() {
+            return Arrays.asList(Map.class);
+        }
+
+        @Override
+        public String toString() {
+            return "Exactly-once source connectors";
+        }
+    };
+
+}

--- a/src/main/java/io/aiven/kafka/connect/common/compatibility/features/MethodFeature.java
+++ b/src/main/java/io/aiven/kafka/connect/common/compatibility/features/MethodFeature.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.compatibility.features;
+
+import java.util.List;
+
+/**
+ * A {@link Feature} whose availability can be determined by checking for the existence of a method at runtime via
+ * reflection.
+ */
+abstract class MethodFeature extends Feature {
+
+    protected boolean checkSupported() {
+        try {
+            final Class<?> klass = klass();
+            klass.getMethod(method(), parameters().toArray(new Class<?>[0]));
+            return true;
+        } catch (final NoSuchMethodException e) {
+            return false;
+        }
+    }
+
+    /**
+     * @return the class whose method should be checked to determine if the feature is supported
+     */
+    protected abstract Class<?> klass();
+
+    /**
+     * @return the name of the method that should be checked to determine if the feature is supported
+     */
+    protected abstract String method();
+
+    /**
+     * @return the parameter types of the method that should be checked to determine if the feature is supported
+     */
+    protected abstract List<Class<?>> parameters();
+
+}

--- a/src/test/java/io/aiven/kafka/connect/common/compatibility/features/FeaturesTest.java
+++ b/src/test/java/io/aiven/kafka/connect/common/compatibility/features/FeaturesTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2022 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.compatibility.features;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class FeaturesTest {
+
+    private void testFeature(
+            final String version,
+            final Collection<Feature> supportedFeatures,
+            final Feature feature
+    ) {
+        final boolean supported = supportedFeatures.contains(feature);
+        final String message = String.format(
+                "This feature should%s be supported with API version %s",
+                supported ? "" : " not",
+                version
+        );
+        assertEquals(supported, feature.supported(), message);
+    }
+
+    private Stream<DynamicTest> testFeatures(final String version, final Collection<Feature> supportedFeatures) {
+        return DynamicTest.stream(
+                Arrays.asList(
+                        Features.SINK_TASK_PRE_COMMIT,
+                        Features.SINK_TASK_ERRANT_RECORD_REPORTER,
+                        Features.EXACTLY_ONCE_SOURCE_CONNECTORS
+                ).iterator(),
+                Object::toString,
+                f -> testFeature(version, supportedFeatures, f)
+        );
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> testFeatures0101() {
+        return testFeatures(
+                "0.10.1.0",
+                Arrays.asList()
+        );
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> testFeatures0102() {
+        return testFeatures(
+                "0102",
+                Arrays.asList(
+                        Features.SINK_TASK_PRE_COMMIT
+                )
+        );
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> testFeatures250() {
+        return testFeatures(
+                "2.5.0",
+                Arrays.asList(
+                        Features.SINK_TASK_PRE_COMMIT
+                )
+        );
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> testFeatures260() {
+        return testFeatures(
+                "2.6.0",
+                Arrays.asList(
+                        Features.SINK_TASK_PRE_COMMIT,
+                        Features.SINK_TASK_ERRANT_RECORD_REPORTER
+                )
+        );
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> testFeatures320() {
+        return testFeatures(
+                "3.2.0",
+                Arrays.asList(
+                        Features.SINK_TASK_PRE_COMMIT,
+                        Features.SINK_TASK_ERRANT_RECORD_REPORTER
+                )
+        );
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> testFeatures330() {
+        return testFeatures(
+                "3.3.0",
+                Arrays.asList(
+                        Features.SINK_TASK_PRE_COMMIT,
+                        Features.SINK_TASK_ERRANT_RECORD_REPORTER,
+                        Features.EXACTLY_ONCE_SOURCE_CONNECTORS
+                )
+        );
+    }
+
+}


### PR DESCRIPTION
Addresses https://github.com/aiven/commons-for-apache-kafka-connect/issues/127 by adding in a couple new APIs:

- The `Features` class can be used to safely and easily determine whether a given feature is supported by the version of Kafka Connect that the plugin has been deployed onto
- The `ErrantRecordReporter` interface can be used to implement error reporting logic with a single unified interface, even if the Kafka Connect runtime does not support the error-reporting feature introduced in [KIP-610](https://cwiki.apache.org/confluence/display/KAFKA/KIP-610%3A+Error+Reporting+in+Sink+Connectors) or the user has not enabled that feature

Some Gradle logic is added to verify that the `Features` API works as expected against a wide range of Kafka Connect versions, by manipulating the version of the `connect-api` artifact that's present on the classpath while executing those tests. A new `allTests` task is introduced that runs these cross-version tests in addition to the normal connector tests; by default, the `build` command now runs these tests as well. Tests for individual versions can be executed with the `testFeatures<version>` task; for example, `./gradlew testFeatures0101 testFeatures250 testFeatures330` will run tests with versions 0.10.1.0, 2.5.0, and 3.3.0 of the Connect API.

In order to add tests for a new version of Kafka Connect, only two changes need to be made:
- The `featureTestingVersions` map needs to be updated with the new version in the Gradle build file
- A new test case needs to be added to the `FeaturesTest` suite

This may make more sense as an official library maintained in the [apache/kafka](https://github.com/apache/kafka) repository; I'm still working through some issues with classloading before proposing that on the mailing list, though. The overall API should still be viable for review even if we end up adding this code elsewhere.