### PR TITLE
use singleton ObjectMapper

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/AbstractJsonOutputStreamWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/AbstractJsonOutputStreamWriter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.output.jsonwriter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import io.aiven.kafka.connect.common.output.OutputStreamWriter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public abstract class AbstractJsonOutputStreamWriter implements OutputStreamWriter {
+
+
+    private final Map<String, OutputFieldBuilder> fieldBuilders;
+    private final boolean envelopeEnabled;
+
+    AbstractJsonOutputStreamWriter(final Map<String, OutputFieldBuilder> fieldBuilders,
+                                   final boolean envelopeEnabled) {
+        this.fieldBuilders = fieldBuilders;
+        this.envelopeEnabled = envelopeEnabled;
+    }
+
+    @Override
+    public void writeOneRecord(final OutputStream outputStream, final SinkRecord record) throws IOException {
+        outputStream.write(ObjectMapperProvider.get().writeValueAsBytes(getFields(record)));
+    }
+
+    JsonNode getFields(final SinkRecord record) throws IOException {
+        if (envelopeEnabled) {
+            final ObjectNode root = JsonNodeFactory.instance.objectNode();
+            final Set<Map.Entry<String, OutputFieldBuilder>> entries = fieldBuilders.entrySet();
+            for (final Map.Entry<String, OutputFieldBuilder> entry : entries) {
+                final JsonNode node = entry.getValue().build(record);
+                root.set(entry.getKey(), node);
+            }
+            return root;
+        } else {
+            // envelope can be disabled only in case of single field
+            return fieldBuilders.entrySet().iterator().next().getValue().build(record);
+        }
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/HeaderBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/HeaderBuilder.java
@@ -25,14 +25,11 @@ import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 class HeaderBuilder implements OutputFieldBuilder {
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private final JsonConverter converter;
 
@@ -66,10 +63,8 @@ class HeaderBuilder implements OutputFieldBuilder {
     }
 
     private JsonNode nodeFromHeader(final Header header, final String topic) throws IOException {
-        return objectMapper.readTree(converter.fromConnectHeader(topic,
-                                                                 header.key(),
-                                                                 header.schema(),
-                                                                 header.value()));
+        return ObjectMapperProvider.get()
+            .readTree(converter.fromConnectHeader(topic, header.key(), header.schema(), header.value()));
 
     }
 }

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/JsonOutputStreamWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/JsonOutputStreamWriter.java
@@ -20,32 +20,16 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.Set;
 
-import org.apache.kafka.connect.sink.SinkRecord;
-
-import io.aiven.kafka.connect.common.output.OutputStreamWriter;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-class JsonOutputStreamWriter implements OutputStreamWriter {
+class JsonOutputStreamWriter extends AbstractJsonOutputStreamWriter {
     private static final byte[] BATCH_START = "[\n".getBytes(StandardCharsets.UTF_8);
     private static final byte[] RECORD_SEPARATOR = ",\n".getBytes(StandardCharsets.UTF_8);
     private static final byte[] BATCH_END = "\n]".getBytes(StandardCharsets.UTF_8);
 
-    private final Map<String, OutputFieldBuilder> fieldBuilders;
-    private final boolean envelopeEnabled;
-    private final ObjectMapper objectMapper;
 
     JsonOutputStreamWriter(final Map<String, OutputFieldBuilder> fieldBuilders,
                            final boolean envelopeEnabled) {
-        this.fieldBuilders = fieldBuilders;
-        this.envelopeEnabled = envelopeEnabled;
-        this.objectMapper = new ObjectMapper();
-        objectMapper.setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
+        super(fieldBuilders, envelopeEnabled);
     }
 
     @Override
@@ -59,27 +43,7 @@ class JsonOutputStreamWriter implements OutputStreamWriter {
     }
 
     @Override
-    public void writeOneRecord(final OutputStream outputStream, final SinkRecord record) throws IOException {
-        outputStream.write(objectMapper.writeValueAsBytes(getFields(record)));
-    }
-
-    @Override
     public void stopWriting(final OutputStream outputStream) throws IOException {
         outputStream.write(BATCH_END);
-    }
-
-    private JsonNode getFields(final SinkRecord record) throws IOException {
-        if (envelopeEnabled) {
-            final ObjectNode root = JsonNodeFactory.instance.objectNode();
-            final Set<Map.Entry<String, OutputFieldBuilder>> entries = fieldBuilders.entrySet();
-            for (final Map.Entry<String, OutputFieldBuilder> entry : entries) {
-                final JsonNode node = entry.getValue().build(record);
-                root.set(entry.getKey(), node);
-            }
-            return root;
-        } else {
-            // envelope can be disabled only in case of single field
-            return fieldBuilders.entrySet().iterator().next().getValue().build(record);
-        }
     }
 }

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/KeyBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/KeyBuilder.java
@@ -25,11 +25,8 @@ import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 class KeyBuilder implements OutputFieldBuilder {
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private final JsonConverter converter;
 
@@ -56,6 +53,7 @@ class KeyBuilder implements OutputFieldBuilder {
             return null;
         }
 
-        return objectMapper.readTree(converter.fromConnectData(record.topic(), record.keySchema(), record.key()));
+        return ObjectMapperProvider.get()
+            .readTree(converter.fromConnectData(record.topic(), record.keySchema(), record.key()));
     }
 }

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/ObjectMapperProvider.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/ObjectMapperProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.output.jsonwriter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Wraps an object mapper for reuse. There should be only a single object mapper created for the whole application.
+ */
+public class ObjectMapperProvider {
+
+    private static final ObjectMapper OBJECT_MAPPER;
+
+    static {
+        OBJECT_MAPPER = new ObjectMapper();
+        OBJECT_MAPPER.setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
+    }
+
+    public static ObjectMapper get() {
+        return OBJECT_MAPPER;
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/ValueBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/ValueBuilder.java
@@ -25,11 +25,8 @@ import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 class ValueBuilder implements OutputFieldBuilder {
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private final JsonConverter converter;
 
@@ -54,8 +51,7 @@ class ValueBuilder implements OutputFieldBuilder {
             return null;
         }
 
-        return objectMapper.readTree(converter.fromConnectData(record.topic(),
-                                                               record.valueSchema(),
-                                                               record.value()));
+        return ObjectMapperProvider.get()
+            .readTree(converter.fromConnectData(record.topic(), record.valueSchema(), record.value()));
     }
 }


### PR DESCRIPTION
Reduces some memory footprint as single reused object mapper is used instead of creating new for each output stream, key, header and value serializer.