### PR TITLE
refactor: improve error message when header types differ

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/common/output/SinkSchemaBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/SinkSchemaBuilder.java
@@ -147,7 +147,9 @@ public abstract class SinkSchemaBuilder {
                 headerSchema = h.schema();
             } else if (headerSchema.type() != h.schema().type()) {
                 throw new DataException("Header schema " + h.schema()
-                    + " is not the same as " + headerSchema);
+                    + " for '" + h.key() + "' "
+                    + "is not the same as the already defined map type: " + headerSchema + ". "
+                    + "To force the same type, consider using StringConverter or similar.");
             }
         }
         return SchemaBuilder.map().values(avroData.fromConnectSchema(headerSchema));

--- a/src/test/java/io/aiven/kafka/connect/common/output/SchemaBuilderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/common/output/SchemaBuilderTest.java
@@ -238,7 +238,7 @@ class SchemaBuilderTest {
         assertThat(avroSchema.getField("value").schema().getType()).isEqualTo(Type.STRING);
     }
 
-    private static Stream<Arguments> multipleFieldsWithoutHeadersTestParameters() {
+    private static Stream<Arguments> schemaBuilders() {
         final var fields = List.of(
             new OutputField(OutputFieldType.KEY, OutputFieldEncodingType.NONE),
             new OutputField(OutputFieldType.VALUE, OutputFieldEncodingType.NONE),
@@ -255,7 +255,7 @@ class SchemaBuilderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("multipleFieldsWithoutHeadersTestParameters")
+    @MethodSource("schemaBuilders")
     void testBuildAivenCustomSchemaForMultipleFields(final SinkSchemaBuilder schemaBuilder) {
         final Headers headers = new ConnectHeaders();
         headers.add("a", "b", Schema.STRING_SCHEMA);
@@ -289,6 +289,7 @@ class SchemaBuilderTest {
 
     @ParameterizedTest
     @MethodSource("multipleFieldsWithoutHeadersTestParameters")
+    @MethodSource("schemaBuilders")
     void testBuildSchemaForMultipleFieldsWithoutHeaders(final SinkSchemaBuilder schemaBuilder) {
         final var sinkRecord =
                 new SinkRecord(


### PR DESCRIPTION
The connector is expecting record headers to be of the same type. This type is used to define the headers map type for the output schema.

The current workaround is to force the same type via converters, e.g. using header converter: `StringConverter` instead of `SimpleHeaderConverter` that tries to infer the type from the value.

There's still another scenario that may cause issues where first record does not have headers but other records may have. This requires further investigation. See https://github.com/Aiven-Open/gcs-connector-for-apache-kafka/issues/347#issuecomment-1964537795 and https://github.com/Aiven-Open/commons-for-apache-kafka-connect/issues/227