### PR TITLE
build: add metadata descriptor to enable kafka connect use the  plugin discovery mechanism

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("aiven-apache-kafka-connectors-all.java-conventions") }

--- a/buildSrc/src/main/kotlin/aiven-apache-kafka-connectors-all.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/aiven-apache-kafka-connectors-all.java-conventions.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import com.diffplug.spotless.LineEnding
 import java.net.URI
 
 plugins {
@@ -124,13 +125,14 @@ spotbugs {
 spotless {
     format("misc") {
         // define the files to apply `misc` to
-        target("*.gradle", "*.md", ".gitignore")
+        target("*.gradle", "*.md", ".gitignore", "**/META-INF/services/**")
         targetExclude(".*/**", "**/build/**", "**/.gradle/**")
 
         // define the steps to apply to those files
         trimTrailingWhitespace()
         indentWithSpaces()
         endWithNewline()
+        // lineEndings = LineEnding.UNIX -> if we want to unify line endings we should set this
     }
 
     kotlinGradle {

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -95,8 +95,8 @@ dependencies {
 distributions {
   main {
     contents {
-      from("jar")
-      from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
+      from(tasks.jar)
+      from(configurations.runtimeClasspath.get())
 
       into("/") {
         from("$projectDir")

--- a/gcs-connector/build.gradle.kts
+++ b/gcs-connector/build.gradle.kts
@@ -186,11 +186,13 @@ tasks.distZip { dependsOn(":commons:jar") }
 distributions {
   main {
     contents {
-      from("jar")
-      from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
+      from(tasks.jar)
+      from(configurations.runtimeClasspath.get())
     }
   }
 }
+
+tasks.installDist { dependsOn(":commons:jar") }
 
 publishing {
   publications {

--- a/gcs-connector/src/main/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
+++ b/gcs-connector/src/main/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
@@ -1,0 +1,1 @@
+io.aiven.kafka.connect.gcs.GcsSinkConnector

--- a/s3-connector/LICENSE
+++ b/s3-connector/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/s3-connector/build.gradle.kts
+++ b/s3-connector/build.gradle.kts
@@ -168,11 +168,13 @@ tasks.distTar { dependsOn(":commons:jar") }
 
 tasks.distZip { dependsOn(":commons:jar") }
 
+tasks.installDist { dependsOn(":commons:jar") }
+
 distributions {
   main {
     contents {
-      from("jar")
-      from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
+      from(tasks.jar)
+      from(configurations.runtimeClasspath.get())
 
       into("/") {
         from("$projectDir")

--- a/s3-connector/src/main/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
+++ b/s3-connector/src/main/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
@@ -1,0 +1,1 @@
+io.aiven.kafka.connect.s3.AivenKafkaConnectS3SinkConnector

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,87 +1,95 @@
 rootProject.name = "aiven-commons-for-apache-kafka-connect"
 
-val assertJVersion by extra ("3.26.0")
-val avroVersion by extra ("1.11.3")
-val avroConverterVersion by extra ("7.2.2")
-val avroDataVersion by extra ("7.2.2")
-val awaitilityVersion by extra ("4.2.1")
-val commonsTextVersion by extra ("1.11.0")
-val hadoopVersion by extra ("3.4.0")
-val hamcrestVersion by extra ("2.2")
-val jacksonVersion by extra ("2.15.3")
-val junitVersion by extra ("5.10.2")
-val jqwikVersion by extra ("1.8.4")
-val kafkaVersion by extra ("1.1.0")
-val logbackVersion by extra ("1.5.6")
-val localstackVersion by extra ("0.2.23")
-val mockitoVersion by extra ("5.12.0")
-val parquetVersion by extra ("1.11.2")
-val slf4jVersion by extra ("1.7.36")
-val snappyVersion by extra ("1.1.10.5")
-val spotbugsAnnotationsVersion by extra ("4.8.1")
-val stax2ApiVersion by extra ("4.2.2")
-val testcontainersVersion by extra ("1.19.8")
-val zstdVersion by extra ("1.5.6-3")
-val wireMockVersion by extra ("2.35.0")
+val assertJVersion by extra("3.26.0")
+val avroVersion by extra("1.11.3")
+val avroConverterVersion by extra("7.2.2")
+val avroDataVersion by extra("7.2.2")
+val awaitilityVersion by extra("4.2.1")
+val commonsTextVersion by extra("1.11.0")
+val hadoopVersion by extra("3.4.0")
+val hamcrestVersion by extra("2.2")
+val jacksonVersion by extra("2.15.3")
+val junitVersion by extra("5.10.2")
+val jqwikVersion by extra("1.8.4")
+val kafkaVersion by extra("1.1.0")
+val logbackVersion by extra("1.5.6")
+val localstackVersion by extra("0.2.23")
+val mockitoVersion by extra("5.12.0")
+val parquetVersion by extra("1.11.2")
+val slf4jVersion by extra("1.7.36")
+val snappyVersion by extra("1.1.10.5")
+val spotbugsAnnotationsVersion by extra("4.8.1")
+val stax2ApiVersion by extra("4.2.2")
+val testcontainersVersion by extra("1.19.8")
+val zstdVersion by extra("1.5.6-3")
+val wireMockVersion by extra("2.35.0")
 
 dependencyResolutionManagement {
-    versionCatalogs {
-        create("apache") {
-            library("avro", "org.apache.avro:avro:$avroVersion")
-            library("commons-text", "org.apache.commons:commons-text:$commonsTextVersion")
-            library("kafka-connect-api","org.apache.kafka:connect-api:$kafkaVersion")
-            library("kafka-connect-json", "org.apache.kafka:connect-json:$kafkaVersion")
-            library("kafka-connect-runtime", "org.apache.kafka:connect-runtime:$kafkaVersion")
-            library("kafka-connect-transforms", "org.apache.kafka:connect-transforms:$kafkaVersion")
-            library("hadoop-common", "org.apache.hadoop:hadoop-common:$hadoopVersion")
-            library("hadoop-mapreduce-client-core", "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoopVersion")
-            library("parquet-avro", "org.apache.parquet:parquet-avro:$parquetVersion")
-            library("parquet-tools", "org.apache.parquet:parquet-tools:$parquetVersion")
-        }
-        create("compressionlibs") {
-            library("snappy", "org.xerial.snappy:snappy-java:$snappyVersion")
-            library("zstd-jni", "com.github.luben:zstd-jni:$zstdVersion")
-        }
-        create("confluent") {
-            library("kafka-connect-avro-converter", "io.confluent:kafka-connect-avro-converter:$avroConverterVersion")
-            library("kafka-connect-avro-data", "io.confluent:kafka-connect-avro-data:$avroDataVersion")
-        }
-        create("jackson") {
-            library("databind", "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-        }
-        create("kafkalibs") {
-
-        }
-        create("logginglibs") {
-            library("logback-classic", "ch.qos.logback:logback-classic:$logbackVersion")
-            library("slf4j", "org.slf4j:slf4j-api:$slf4jVersion")
-            library("slf4j-log4j12", "org.slf4j:slf4j-log4j12:$slf4jVersion")
-        }
-        create("tools") {
-            library("spotbugs-annotations", "com.github.spotbugs:spotbugs-annotations:$spotbugsAnnotationsVersion")
-        }
-        create("testinglibs") {
-            library("assertj-core", "org.assertj:assertj-core:$assertJVersion")
-            library("awaitility", "org.awaitility:awaitility:$awaitilityVersion")
-            library("hamcrest", "org.hamcrest:hamcrest:$hamcrestVersion")
-            library("localstack", "cloud.localstack:localstack-utils:$localstackVersion")
-            library("junit-jupiter", "org.junit.jupiter:junit-jupiter:$junitVersion")
-            library("junit-jupiter-engine", "org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-            library("jqwik", "net.jqwik:jqwik:$jqwikVersion")
-            library("jqwik-engine", "net.jqwik:jqwik-engine:$jqwikVersion")
-            library("mockito-core", "org.mockito:mockito-core:$mockitoVersion")
-            library("mockito-junit-jupiter", "org.mockito:mockito-junit-jupiter:$mockitoVersion")
-            library("wiremock", "com.github.tomakehurst:wiremock-jre8:$wireMockVersion")
-            library("woodstox-stax2-api", "org.codehaus.woodstox:stax2-api:$stax2ApiVersion")
-        }
-        create("testcontainers") {
-            library("junit-jupiter", "org.testcontainers:junit-jupiter:$testcontainersVersion")
-            library("kafka", "org.testcontainers:kafka:$testcontainersVersion")  // this is not Kafka version
-            library("localstack", "org.testcontainers:localstack:$testcontainersVersion")
-        }
+  versionCatalogs {
+    create("apache") {
+      library("avro", "org.apache.avro:avro:$avroVersion")
+      library("commons-text", "org.apache.commons:commons-text:$commonsTextVersion")
+      library("kafka-connect-api", "org.apache.kafka:connect-api:$kafkaVersion")
+      library("kafka-connect-json", "org.apache.kafka:connect-json:$kafkaVersion")
+      library("kafka-connect-runtime", "org.apache.kafka:connect-runtime:$kafkaVersion")
+      library("kafka-connect-transforms", "org.apache.kafka:connect-transforms:$kafkaVersion")
+      library("hadoop-common", "org.apache.hadoop:hadoop-common:$hadoopVersion")
+      library(
+          "hadoop-mapreduce-client-core",
+          "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoopVersion")
+      library("parquet-avro", "org.apache.parquet:parquet-avro:$parquetVersion")
+      library("parquet-tools", "org.apache.parquet:parquet-tools:$parquetVersion")
     }
+    create("compressionlibs") {
+      library("snappy", "org.xerial.snappy:snappy-java:$snappyVersion")
+      library("zstd-jni", "com.github.luben:zstd-jni:$zstdVersion")
+    }
+    create("confluent") {
+      library(
+          "kafka-connect-avro-converter",
+          "io.confluent:kafka-connect-avro-converter:$avroConverterVersion")
+      library("kafka-connect-avro-data", "io.confluent:kafka-connect-avro-data:$avroDataVersion")
+    }
+    create("jackson") {
+      library("databind", "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+    }
+    create("kafkalibs") {}
+
+    create("logginglibs") {
+      library("logback-classic", "ch.qos.logback:logback-classic:$logbackVersion")
+      library("slf4j", "org.slf4j:slf4j-api:$slf4jVersion")
+      library("slf4j-log4j12", "org.slf4j:slf4j-log4j12:$slf4jVersion")
+    }
+    create("tools") {
+      library(
+          "spotbugs-annotations",
+          "com.github.spotbugs:spotbugs-annotations:$spotbugsAnnotationsVersion")
+    }
+    create("testinglibs") {
+      library("assertj-core", "org.assertj:assertj-core:$assertJVersion")
+      library("awaitility", "org.awaitility:awaitility:$awaitilityVersion")
+      library("hamcrest", "org.hamcrest:hamcrest:$hamcrestVersion")
+      library("localstack", "cloud.localstack:localstack-utils:$localstackVersion")
+      library("junit-jupiter", "org.junit.jupiter:junit-jupiter:$junitVersion")
+      library("junit-jupiter-engine", "org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+      library("jqwik", "net.jqwik:jqwik:$jqwikVersion")
+      library("jqwik-engine", "net.jqwik:jqwik-engine:$jqwikVersion")
+      library("mockito-core", "org.mockito:mockito-core:$mockitoVersion")
+      library("mockito-junit-jupiter", "org.mockito:mockito-junit-jupiter:$mockitoVersion")
+      library("wiremock", "com.github.tomakehurst:wiremock-jre8:$wireMockVersion")
+      library("woodstox-stax2-api", "org.codehaus.woodstox:stax2-api:$stax2ApiVersion")
+    }
+    create("testcontainers") {
+      library("junit-jupiter", "org.testcontainers:junit-jupiter:$testcontainersVersion")
+      library(
+          "kafka", "org.testcontainers:kafka:$testcontainersVersion") // this is not Kafka version
+      library("localstack", "org.testcontainers:localstack:$testcontainersVersion")
+    }
+  }
 }
 
 include("commons")
+
 include("gcs-connector")
+
 include("s3-connector")


### PR DESCRIPTION
This pr add the descriptors to enable kafka connect loading the connectors just by scanning the plugin jars.
The specific require creating a file called `META-INF/services/org.apache.kafka.connect.sink.SinkConnector` (note well that this is the interface, not the implementation. I've done this error before).
The content of the file should be the fully qualified classname of the file implementing the interface.


To check that the modification its accepted you can use a cli tool, e.g. `/opt/kafka-3.6/bin/connect-plugin-path.sh list --plugin-path /opt/myFancyFolder/kafka-connect-bigquery/`.
The output will be like:
```
pluginName	firstAlias	secondAlias	pluginVersion	pluginType	isLoadable	hasManifest	pluginLocation
com.wepay.kafka.connect.bigquery.BigQuerySinkConnector	BigQuerySinkConnector	BigQuerySink	unknown	sink	true	true	/opt/myFancyFolder/connect-plugins/kafka-connect-bigquery/kcbq-connector-2.6.1-SNAPSHOT.jar
io.debezium.transforms.UnwrapFromEnvelope	UnwrapFromEnvelope	N/A	undefined	transformation	true	false	/opt/myFancyFolderconnect-plugins/kafka-connect-bigquery/debezium-core-0.6.2.jar
io.debezium.transforms.ByLogicalTableRouter	ByLogicalTableRouter	N/A	undefined	transformation	true	false	/opt/myFancyFolder/connect-plugins/kafka-connect-bigquery/debezium-core-0.6.2.jar
```

In this example the `hasManifest` its true just for the `kafka-connect-bigquery/kcbq-connector-2.6.1-SNAPSHOT.jar` meaning that the jar containing the implementation under `META-INF/services/org.apache.kafka.connect.sink.SinkConnector` has 1 row with specified `com.wepay.kafka.connect.bigquery.BigQuerySinkConnector	`.
While the other two classes under `/opt/myFancyFolder/connect-plugins/kafka-connect-bigquery/debezium-core-0.6.2.jar` have two transformations that can be scanned with a runtime scanner (basically checking with the reflection for each class if its implementing the method) but do not have a valid descriptor for them.

NB with the descriptor the scan time its several orders of time faster for non trivial classpath (classpath with multiple big jars ~= 2/300 MB)